### PR TITLE
Updated README and fixed bugs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,6 @@
 .gitignore
 
 # Large data files — mounted at runtime
-bioportal.db
 indexes_embedding/
 *.db
 
@@ -11,7 +10,7 @@ indexes_embedding/
 __pycache__/
 *.pyc
 *.pyo
-.cache/
+.ontology/
 *.egg-info/
 
 # Logs

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ logs/
 build/
 .env
 .vscode/
-bioportal.db
-.cache/
+.ontology/
 .venv/
 tests/.venv/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,10 +18,11 @@ services:
       # Mount cache for model persistence
       - ${CACHE_ROOT:-./.ontology}:/app/.cache    # Docker will auto create ${CACHE_ROOT} if it does not exist
     environment:
-      # Cache Env 
+      # Cache Env
       - BM25_CACHE_DIR=${BM25_CACHE_DIR}
       - INDEX_CACHE_DIR=${INDEX_CACHE_DIR}
       - EMBED_CACHE_DIR=${EMBED_CACHE_DIR}
+      - DATABASE_PATH=/app/bioportal.db
 
       # API Configuration
       - API_HOST=0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       # Mount database
       - ./bioportal.db:/app/bioportal.db:ro
       # Mount cache for model persistence
-      - ${CACHE_ROOT:-./.cache}:/app/.cache    # Docker will auto create ${CACHE_ROOT} if it does not exist
+      - ${CACHE_ROOT:-./.ontology}:/app/.cache    # Docker will auto create ${CACHE_ROOT} if it does not exist
     environment:
       # Cache Env 
       - BM25_CACHE_DIR=${BM25_CACHE_DIR}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - "18000:8000"
     volumes:
       # Mount database
-      - ./bioportal.db:/app/bioportal.db:ro
+      - ${CACHE_ROOT:-./.ontology}/bioportal.db:/app/bioportal.db:ro
       # Mount cache for model persistence
       - ${CACHE_ROOT:-./.ontology}:/app/.cache    # Docker will auto create ${CACHE_ROOT} if it does not exist
     environment:

--- a/env.example
+++ b/env.example
@@ -161,7 +161,7 @@ EMBED_CACHE_DIR=${CACHE_ROOT}/embed_indexes
 BM25_CACHE_DIR=${CACHE_ROOT}/bm25_indexes
 
 # Database path
-DATABASE_PATH=bioportal.db
+DATABASE_PATH=${CACHE_ROOT}/bioportal.db
 
 # ============================================================================
 # API Configuration

--- a/env.example
+++ b/env.example
@@ -30,7 +30,7 @@ EMBEDDING_MODEL=BAAI/bge-small-en-v1.5
 VECTOR_BACKEND=faiss
 
 # Only needed when VECTOR_BACKEND=chroma (not recommended for large datasets):
-# CHROMA_DB_PATH=.cache/chroma_db
+# CHROMA_DB_PATH=.ontology/chroma_db
 
 # ============================================================================
 # Re-ranking Configuration
@@ -141,13 +141,13 @@ MAX_CANDIDATES=20
 # Per-API call limit
 MAX_RESULTS=5
 
-# (1) Root directory that contains any pre-indexed BM25 and/or FAISS files. The default location is .cache 
+# (1) Root directory that contains any pre-indexed BM25 and/or FAISS files. The default location is .ontology
 # in the current directory. Set the value to the desired directory location. E.g. "./indexed_files"
 # (2) Add this location to the .dockerignore file to avoid copying the index files to the Docker image.
 # Instead, the index files can be bind mounted, see the example in docker-compose.yml.
 # (3) Make sure to either use absolute path or relative paths starting with ./ or ../. Otherwise, the 
 # path name can be confused with named volumes.
-CACHE_ROOT=./.cache
+CACHE_ROOT=./.ontology
 
 # Index cache directory (BM25 indexes)
 # Pre-built BM25 indexes are stored here for faster startup

--- a/main.py
+++ b/main.py
@@ -204,7 +204,7 @@ async def lifespan(app: FastAPI):
     try:
         # Initialize database
         global db, retriever, reranker, _indexing_complete
-        db = OntologyDB(db_path=os.getenv("DATABASE_PATH", "bioportal.db"))
+        db = OntologyDB(db_path=os.getenv("DATABASE_PATH", "./.ontology/bioportal.db"))
         
         # Log database stats
         stats = db.get_stats()

--- a/main.py
+++ b/main.py
@@ -204,7 +204,7 @@ async def lifespan(app: FastAPI):
     try:
         # Initialize database
         global db, retriever, reranker, _indexing_complete
-        db = OntologyDB(db_path="bioportal.db")
+        db = OntologyDB(db_path=os.getenv("DATABASE_PATH", "bioportal.db"))
         
         # Log database stats
         stats = db.get_stats()

--- a/main.py
+++ b/main.py
@@ -218,7 +218,7 @@ async def lifespan(app: FastAPI):
         bm25_weight = float(os.getenv("BM25_WEIGHT", "0.3"))
         dense_weight = float(os.getenv("DENSE_WEIGHT", "0.7"))
         embedding_model = os.getenv("EMBEDDING_MODEL", "sentence-transformers/all-MiniLM-L6-v2")
-        chroma_path = os.getenv("CHROMA_DB_PATH", ".cache/chroma_db")
+        chroma_path = os.getenv("CHROMA_DB_PATH", ".ontology/chroma_db")
 
         # VECTOR_BACKEND controls the dense index backend:
         #   faiss  — recommended for >1M vectors (exact cosine, builds in seconds)
@@ -231,12 +231,12 @@ async def lifespan(app: FastAPI):
         retriever = HybridRetriever(
             bm25_weight=bm25_weight,
             dense_weight=dense_weight,
-            bm25_model=BM25Retriever(cache_dir=os.getenv("BM25_CACHE_DIR", ".cache/bm25_indexes")),
+            bm25_model=BM25Retriever(cache_dir=os.getenv("BM25_CACHE_DIR", ".ontology/bm25_indexes")),
             dense_model=DenseRetriever(
                 model_name=embedding_model,
                 use_chroma=use_chroma,
                 chroma_path=chroma_path,
-                embed_cache_dir=os.getenv("EMBED_CACHE_DIR", ".cache/embed_indexes"),
+                embed_cache_dir=os.getenv("EMBED_CACHE_DIR", ".ontology/embed_indexes"),
                 use_faiss=use_faiss,
             ),
         )
@@ -309,7 +309,7 @@ def _build_indexes():
     import pickle
 
     try:
-        cache_dir = os.getenv("INDEX_CACHE_DIR", ".cache/ontology_indexes")
+        cache_dir = os.getenv("INDEX_CACHE_DIR", ".ontology/ontology_indexes")
         os.makedirs(cache_dir, exist_ok=True)
         concepts_cache_path = os.path.join(cache_dir, "concepts_cache.pkl")
         concepts_meta_path  = os.path.join(cache_dir, "concepts_cache_meta.json")
@@ -977,7 +977,7 @@ async def get_stats():
             indexes={
                 "bm25_indexed": _indexing_complete,
                 "dense_indexed": _indexing_complete,
-                "cache_dir": os.getenv("INDEX_CACHE_DIR", ".cache/ontology_indexes"),
+                "cache_dir": os.getenv("INDEX_CACHE_DIR", ".ontology/ontology_indexes"),
                 "num_indexed_concepts": len(_concepts_map),
             },
             configuration=config,
@@ -1018,8 +1018,8 @@ async def get_config():
             "log_level":  os.getenv("LOG_LEVEL",    "INFO"),
         },
         "cache": {
-            "index_cache_dir": os.getenv("INDEX_CACHE_DIR", ".cache/ontology_indexes"),
-            "embed_cache_dir": os.getenv("EMBED_CACHE_DIR", ".cache/embed_indexes"),
+            "index_cache_dir": os.getenv("INDEX_CACHE_DIR", ".ontology/ontology_indexes"),
+            "embed_cache_dir": os.getenv("EMBED_CACHE_DIR", ".ontology/embed_indexes"),
             "database_path":   os.getenv("DATABASE_PATH",  "bioportal.db"),
         },
         "status": {

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,14 @@ Based on our evaluation (to be published in a forthcoming paper), a single LLM-b
 
 ## ⚡ Quick Start
 
-### 1. Download Data
+### 1. Clone the Repository
+
+```bash
+git clone https://github.com/sensein/search_hybrid.git
+cd search_hybrid
+```
+
+### 2. Download Data
 
 You must download the Ontology DB, indexes, and embeddings and place them into a `.ontology/` directory.
 
@@ -78,7 +85,7 @@ unzip .ontology/embeddings/embed_indexes.zip -d .ontology/
 unzip .ontology/embeddings/ontology_indexes-20260310T133457Z-3-001.zip -d .ontology/
 ```
 
-### 2. Configure Environment
+### 3. Configure Environment
 
 Copy the example environment file:
 
@@ -92,7 +99,7 @@ If you downloaded the data into a directory other than `.ontology`, update `CACH
 CACHE_ROOT=your-directory-name
 ```
 
-### 3. Choose Your Execution Method
+### 4. Choose Your Execution Method
 
 #### Option A: Docker Deployment (Recommended)
 

--- a/readme.md
+++ b/readme.md
@@ -52,32 +52,41 @@ Based on our evaluation (to be published in a forthcoming paper), a single LLM-b
 
 ## ⚡ Quick Start
 
-### 1. Install dependencies
+### 1. Download Data
+
+You must download the Ontology DB, indexes, and embeddings and place them into a `.cache/` directory.
+
+The easiest way to do this is using Git (requires [Git LFS](https://git-lfs.com)):
+
+```bash
+git clone https://huggingface.co/datasets/sensein/ontology-sqlite-vectorstore .cache
+```
+
+Alternatively, if you have the `huggingface_hub` Python package installed, you can use the CLI:
+
+```bash
+hf download sensein/ontology-sqlite-vectorstore --repo-type dataset --local-dir .cache
+```
+
+> **Note:** The directory does not have to be named `.cache` — use any name you like. Just make sure to update the environment variables accordingly to point to the correct location. If the app doesn't find the indexes, it will run the pipeline to generate them. This is very time-consuming and can take days depending on your system.
+
+### 2. Choose Your Execution Method
+
+#### Option A: Docker Deployment (Recommended)
+
+This will automatically install dependencies and start the server in a container.
+
+```bash
+docker compose up
+```
+
+#### Option B: Local Deployment
+
+If you prefer to run the server directly on your machine without Docker, install the dependencies and run the Uvicorn server:
 
 ```bash
 pip install -r requirements.txt
-```
-
-### 2. Download data
-
-- Ontology DB + indexes + embeddings:
-https://huggingface.co/datasets/sensein/ontology-sqlite-vectorstore
-
-Place into:
-```
-.cache/
-``` 
-Note: It does not have to be `.cache`, it can be any name. Just make sure to update the environment variables accordingly to point to the correct location. If it doesn't find the indexes, then it will run the pipeline to generate indexes + embeddings, which is very time consuming and depending on your system, can take up to days or more.
-
-### 3. Run server
-
-```bash
 python -m uvicorn main:app --reload --port 8000
-```
-
-### 4. Docker Deployment
-```bash
-docker compose up
 ```
 
 ---

--- a/readme.md
+++ b/readme.md
@@ -54,28 +54,28 @@ Based on our evaluation (to be published in a forthcoming paper), a single LLM-b
 
 ### 1. Download Data
 
-You must download the Ontology DB, indexes, and embeddings and place them into a `.cache/` directory.
+You must download the Ontology DB, indexes, and embeddings and place them into a `.ontology/` directory.
 
 The easiest way to do this is using Git (requires [Git LFS](https://git-lfs.com)):
 
 ```bash
-git clone https://huggingface.co/datasets/sensein/ontology-sqlite-vectorstore .cache
+git clone https://huggingface.co/datasets/sensein/ontology-sqlite-vectorstore .ontology
 ```
 
 Alternatively, if you have the `huggingface_hub` Python package installed, you can use the CLI:
 
 ```bash
-hf download sensein/ontology-sqlite-vectorstore --repo-type dataset --local-dir .cache
+hf download sensein/ontology-sqlite-vectorstore --repo-type dataset --local-dir .ontology
 ```
 
-> **Note:** The directory does not have to be named `.cache` — use any name you like. Just make sure to update the environment variables accordingly to point to the correct location. If the app doesn't find the indexes, it will run the pipeline to generate them. This is very time-consuming and can take days depending on your system.
+> **Note:** The directory does not have to be named `.ontology` — use any name you like. Just make sure to update the environment variables accordingly to point to the correct location. If the app doesn't find the indexes, it will run the pipeline to generate them. This is very time-consuming and can take days depending on your system.
 
 Once downloaded, unzip the index files from the `embeddings/` subdirectory into your cache directory:
 
 ```bash
-unzip .cache/embeddings/bm25_indexes-20260310T132934Z-3-001.zip -d .cache/
-unzip .cache/embeddings/embed_indexes.zip -d .cache/
-unzip .cache/embeddings/ontology_indexes-20260310T133457Z-3-001.zip -d .cache/
+unzip .ontology/embeddings/bm25_indexes-20260310T132934Z-3-001.zip -d .ontology/
+unzip .ontology/embeddings/embed_indexes.zip -d .ontology/
+unzip .ontology/embeddings/ontology_indexes-20260310T133457Z-3-001.zip -d .ontology/
 ```
 
 ### 2. Configure Environment
@@ -86,7 +86,7 @@ Copy the example environment file:
 cp env.example .env
 ```
 
-If you downloaded the data into a directory other than `.cache`, update `CACHE_ROOT` in your `.env`:
+If you downloaded the data into a directory other than `.ontology`, update `CACHE_ROOT` in your `.env`:
 
 ```bash
 CACHE_ROOT=your-directory-name
@@ -129,9 +129,9 @@ DENSE_WEIGHT=0.7
 EMBEDDING_MODEL=BAAI/bge-small-en-v1.5   # Embedding model (fast, biomedical-friendly)
 
 VECTOR_BACKEND=faiss         # faiss (default) | numpy | chroma
-EMBED_CACHE_DIR=.cache/embed_indexes    # Where .npy and FAISS index are stored
+EMBED_CACHE_DIR=.ontology/embed_indexes    # Where .npy and FAISS index are stored
 BM25_CACHE_DIR=indexes_embedding/bm25_indexes # BM25 index cache directory
-CHROMA_DB_PATH=.cache/chroma_db        # Only used when VECTOR_BACKEND=chroma
+CHROMA_DB_PATH=.ontology/chroma_db        # Only used when VECTOR_BACKEND=chroma
 ```
 
 ### Re-ranking
@@ -189,8 +189,8 @@ LATE_INTERACTION_MODEL=jinaai/jina-colbert-v2
 ```bash
 MAX_CANDIDATES=20            # Candidates retrieved before re-ranking
 MAX_RESULTS=5                # Default max results per query
-INDEX_CACHE_DIR=.cache/ontology_indexes
-EMBED_CACHE_DIR=.cache/embed_indexes
+INDEX_CACHE_DIR=.ontology/ontology_indexes
+EMBED_CACHE_DIR=.ontology/embed_indexes
 DATABASE_PATH=bioportal.db
 ```
 
@@ -220,7 +220,7 @@ DATABASE_PATH=bioportal.db
 
 ## 🏗️ Indexing
 
-Use `build_index.py` to generate all indexes before starting the server. Note, building indexes is very time consuming task. You can download it from [https://huggingface.co/datasets/sensein/ontology-sqlite-vectorstore](https://huggingface.co/datasets/sensein/ontology-sqlite-vectorstore) and place it on `.cache` directory.
+Use `build_index.py` to generate all indexes before starting the server. Note, building indexes is very time consuming task. You can download it from [https://huggingface.co/datasets/sensein/ontology-sqlite-vectorstore](https://huggingface.co/datasets/sensein/ontology-sqlite-vectorstore) and place it on `.ontology` directory.
 
 ```bash
 # Build with default settings (reads from .env)

--- a/readme.md
+++ b/readme.md
@@ -99,6 +99,12 @@ If you downloaded the data into a directory other than `.ontology`, update `CACH
 CACHE_ROOT=your-directory-name
 ```
 
+Also add that directory to `.gitignore` to avoid accidentally committing large data files, and to ensure Docker does not copy it into the image during `docker compose up`:
+
+```bash
+echo "your-directory-name/" >> .gitignore
+```
+
 ### 4. Choose Your Execution Method
 
 #### Option A: Docker Deployment (Recommended)
@@ -106,7 +112,7 @@ CACHE_ROOT=your-directory-name
 This will automatically install dependencies and start the server in a container.
 
 ```bash
-docker compose up
+docker compose up --build
 ```
 
 #### Option B: Local Deployment

--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,14 @@ hf download sensein/ontology-sqlite-vectorstore --repo-type dataset --local-dir 
 
 > **Note:** The directory does not have to be named `.cache` — use any name you like. Just make sure to update the environment variables accordingly to point to the correct location. If the app doesn't find the indexes, it will run the pipeline to generate them. This is very time-consuming and can take days depending on your system.
 
+Once downloaded, unzip the index files from the `embeddings/` subdirectory into your cache directory:
+
+```bash
+unzip .cache/embeddings/bm25_indexes-20260310T132934Z-3-001.zip -d .cache/
+unzip .cache/embeddings/embed_indexes.zip -d .cache/
+unzip .cache/embeddings/ontology_indexes-20260310T133457Z-3-001.zip -d .cache/
+```
+
 ### 2. Choose Your Execution Method
 
 #### Option A: Docker Deployment (Recommended)

--- a/readme.md
+++ b/readme.md
@@ -78,7 +78,21 @@ unzip .cache/embeddings/embed_indexes.zip -d .cache/
 unzip .cache/embeddings/ontology_indexes-20260310T133457Z-3-001.zip -d .cache/
 ```
 
-### 2. Choose Your Execution Method
+### 2. Configure Environment
+
+Copy the example environment file:
+
+```bash
+cp env.example .env
+```
+
+If you downloaded the data into a directory other than `.cache`, update `CACHE_ROOT` in your `.env`:
+
+```bash
+CACHE_ROOT=your-directory-name
+```
+
+### 3. Choose Your Execution Method
 
 #### Option A: Docker Deployment (Recommended)
 


### PR DESCRIPTION
Summary

Rewrites the Quick Start section of the README and fixes several issues that would prevent the server from running out-of-the-box.

README improvements:
- Restructured steps: Clone → Download → Configure → Run
- Added explicit download commands: git clone (Git LFS) and hf download CLI; updated deprecated huggingface-cli to hf
- Added unzip commands for the three index zip files (bm25_indexes, embed_indexes, ontology_indexes)
- Added env setup step: copy env.example to .env, update CACHE_ROOT if using a custom directory, and add it to .gitignore
- Presented execution as two explicit options (Docker recommended, local as alternative)
- Updated Docker command to docker compose up --build to ensure a fresh image on each run

Bug fixes:
- Renamed default data directory from .cache to .ontology across README.md, env.example, docker-compose.yml, .gitignore, and .dockerignore — more descriptive and avoids implying the data is disposable
- Fixed DATABASE_PATH in env.example to use ${CACHE_ROOT}/bioportal.db since bioportal.db lives inside the downloaded dataset directory
- Fixed docker-compose.yml volume mount for bioportal.db from hardcoded ./bioportal.db to ${CACHE_ROOT:-./.ontology}/bioportal.db
- Added DATABASE_PATH=/app/bioportal.db to the docker-compose.yml environment section so the container resolves the DB to its mounted path
- Fixed main.py to read DATABASE_PATH from the environment instead of hardcoding "bioportal.db"; updated fallback default to ./.ontology/bioportal.db
- Removed redundant bioportal.db entries from .gitignore and .dockerignore — covered by .ontology/